### PR TITLE
fix: add check for flushed headers on error callback

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,7 +88,9 @@ function fastProxy (opts = {}) {
       }
       request(reqParams, (err, response) => {
         if (err) {
-          if (!res.sent) {
+          // check if response has already been sent and all data has been flushed 
+          // before configuring error response headers
+          if (res.sent === false || res.writableFinished === false) {
             if (err.code === 'ECONNREFUSED' || err.code === 'ERR_HTTP2_STREAM_CANCEL') {
               res.statusCode = 503
               res.end('Service Unavailable')

--- a/test/1.smoke.test.js
+++ b/test/1.smoke.test.js
@@ -25,6 +25,11 @@ describe('fast-proxy smoke', () => {
     gateway.use(bodyParser.urlencoded({ extended: true }))
     gateway.use(bodyParser.text())
 
+    gateway.get('/service/flushed', function(req, res) {
+      res.end();
+      proxy(req, res, req.url, {})
+    })
+
     gateway.all('/service/*', function (req, res) {
       proxy(req, res, req.url, {})
     })
@@ -42,6 +47,12 @@ describe('fast-proxy smoke', () => {
     await request(gHttpServer)
       .get('/service/get')
       .expect(503)
+  })
+
+  it('should 200 when proxy errors after response has been sent', async () => {
+    await request(gHttpServer)
+      .get('/service/flushed')
+      .expect(200);
   })
 
   it('init & start remote service', async () => {


### PR DESCRIPTION
This will hopefully resolved https://github.com/Lullabot/tugboat/issues/4902 while we await `fast-proxy` to approve the pr.

`v2.1.0-tugboat` was created off of `v2.1.0-double-slash-fix` so it should be the `fast-proxy` tag `v2.1.0` with @q0rban fix for the double slash. I then created my fix off of this branch which I am now requesting to merge into this branch so we can use it in Tugboat